### PR TITLE
Update value of innodb_file_per_table

### DIFF
--- a/vars/cnf_innodb.yml
+++ b/vars/cnf_innodb.yml
@@ -71,7 +71,7 @@ percona_mysql_innodb_variables:
     comment:
     option: innodb_file_per_table
     variable: innodb_file_per_table
-    value: 'ON'
+    value: 1
     include: true
     dynamic: true
   percona_mysql_innodb_open_files:


### PR DESCRIPTION
Value of 'ON' is ignored in my.cnf on startup, works only for set global innodb_file_per_table command
